### PR TITLE
support FB CoA implementation

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -145,7 +145,7 @@ func IsAuthenticRequest(request, secret []byte) bool {
 	}
 
 	switch Code(request[0]) {
-	case CodeAccessRequest:
+	case CodeAccessRequest, CodeCoAACK, CodeDisconnectACK:
 		return true
 	case CodeAccountingRequest, CodeDisconnectRequest, CodeCoARequest:
 		hash := md5.New()


### PR DESCRIPTION
In order to support the current FB CoA design, we need to allow use of Linux SO_REUSEPORT for sockets. We also need to allow CoA/Disconnect ACK's as requests.