### PR TITLE
[coa] Match IsAuthenticRequest=true for Coa/Disconnect NAKs. 

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -145,7 +145,7 @@ func IsAuthenticRequest(request, secret []byte) bool {
 	}
 
 	switch Code(request[0]) {
-	case CodeAccessRequest, CodeCoAACK, CodeDisconnectACK:
+	case CodeAccessRequest, CodeCoAACK, CodeDisconnectACK, CodeCoANAK, CodeDisconnectNAK:
 		return true
 	case CodeAccountingRequest, CodeDisconnectRequest, CodeCoARequest:
 		hash := md5.New()


### PR DESCRIPTION
This is another hack to get CoA/Disconnects working for us. I don't really like doing it this way but this will help unblock my continued testing. Lets discuss better ways to handle this.

With this change, the CoA/Disconnect client will need to validate response packets itself. This is doable as long as we have both response and request packets.